### PR TITLE
SQCPPGHA-13 Rebranding

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 An example of a flawed C++ code. The https://github.com/sonarsource-cfamily-examples/code[code repository] can be https://github.com/sonarsource-cfamily-examples/automatic-analysis-sc[analyzed automatically], but it can also be compiled with different build systems using different CI pipelines on Linux, macOS, and Windows.
 
 The https://github.com/sonarsource-cfamily-examples/code[code repository] is forked into other repositories in https://github.com/sonarsource-cfamily-examples[this collection] to add a specific build system, platform, and CI.
-The downstream repositories are analyzed either with https://www.sonarqube.org/[SonarQube] or https://sonarcloud.io/[SonarCloud].
+The downstream repositories are analyzed either with https://www.sonarsource.com/products/sonarqube/[SonarQube Server] or https://www.sonarsource.com/products/sonarcloud/[SonarQube Cloud].
 
 You can find examples for:
 
@@ -30,8 +30,8 @@ Running on the following CI services:
 
 Configured for analysis on:
 
-* https://github.com/sonarsource-cfamily-examples?q=-sq[SonarQube]
-* https://github.com/sonarsource-cfamily-examples?q=-sc[SonarCloud]
+* https://github.com/sonarsource-cfamily-examples?q=-sq[SonarQube Server]
+* https://github.com/sonarsource-cfamily-examples?q=-sc[SonarQube Cloud]
 
 You can find also a few examples demonstrating:
 


### PR DESCRIPTION
The [`sonarqube-scan-action@v4.2`](https://github.com/SonarSource/sonarqube-scan-action/releases/tag/v4.2.1) GHA now handles C, C++, and Objective-C projects even when Build Wrapper is needed, replacing `sonarqube-github-c-cpp`.

While doing the replacement, we are also rebranding.